### PR TITLE
ci: configure audit workflow x6

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -37,15 +37,19 @@ jobs:
           - name: Check if audit is needed
             id: audit_needed
             run: |
-                  BASE_SHA=${{ github.event.before }}
-                  if [ -z "$BASE_SHA" ]; then BASE_SHA=$(git rev-parse HEAD~1); fi
-                  if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -Eq 'Cargo\.toml|Cargo\.lock'; then
-                    echo "Rust dependency files changed"
-                    echo "audit_needed=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "No Rust dependency changes"
-                    echo "audit_needed=false" >> $GITHUB_OUTPUT
-                  fi
+              BASE_SHA="${{ github.event.before }}"
+              CURRENT_SHA="${{ github.sha }}"
+
+              # Fallback if BASE_SHA is empty
+              if [ -z "$BASE_SHA" ]; then
+                BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || echo "$CURRENT_SHA")
+              fi
+
+              if git diff --name-only "$BASE_SHA" "$CURRENT_SHA" | grep -Eq 'Cargo\.toml|Cargo\.lock'; then
+                echo "audit_needed=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "audit_needed=false" >> "$GITHUB_OUTPUT"
+              fi
 
     security_audit:
         if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && needs.audit_needed.audit_needed == 'true'}}

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -48,9 +48,9 @@ jobs:
                   fi
 
     security_audit:
-        # if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && needs.audit_needed.audit_needed == 'true'}}
+        if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && needs.audit_needed.audit_needed == 'true'}}
         needs:
-          - audit-needed
+          - audit_needed
         runs-on: ubuntu-24.04
         env:
           MISE_ENV: audit


### PR DESCRIPTION
### TL;DR

Fixed the security audit workflow by uncommenting the conditional check and correcting a dependency name.

### What changed?

- Uncommented the `if` condition for the `security_audit` job that was previously commented out
- Fixed a hyphen typo in the job dependency name from `audit-needed` to `audit_needed` to match the actual job name

### How to test?

1. Push a commit to trigger the GitHub workflow
2. Verify that the security audit job runs correctly when needed
3. Test with a commit containing `[skip ci]` to ensure the job is properly skipped

### Why make this change?

The security audit job was likely not running correctly due to these issues:
1. The conditional check was commented out, causing the job to run regardless of conditions
2. The incorrect dependency name (`audit-needed` instead of `audit_needed`) could cause workflow failures or unexpected behavior